### PR TITLE
DRYD-940: Add checklist extension

### DIFF
--- a/src/plugins/extensions/checklist/fields.js
+++ b/src/plugins/extensions/checklist/fields.js
@@ -1,0 +1,217 @@
+import { defineMessages } from 'react-intl';
+
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+    CompoundInput,
+    DateInput,
+    TermPickerInput,
+    TextInput,
+  } = configContext.inputComponents;
+
+  const {
+    DATA_TYPE_DATE,
+  } = configContext.dataTypes;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  return {
+    'ns2:groups_checklist': {
+      [config]: {
+        service: {
+          ns: 'http://collectionspace.org/services/group/domain/checklist',
+        },
+      },
+      checklistGroupList: {
+        [config]: {
+          view: {
+            type: CompoundInput,
+          },
+        },
+        checklistGroup: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.groups_checklist.checklistGroup.name',
+                defaultMessage: 'Checklists',
+              },
+            }),
+            repeating: true,
+            view: {
+              type: CompoundInput,
+            },
+          },
+          checklistType: {
+            [config]: {
+              messages: defineMessages({
+                fullName: {
+                  id: 'field.groups_checklist.checklistType.fullName',
+                  defaultMessage: 'Checklist type',
+                },
+                name: {
+                  id: 'field.groups_checklist.checklistType.name',
+                  defaultMessage: 'Type',
+                },
+              }),
+              view: {
+                type: TermPickerInput,
+                props: {
+                  source: 'checklisttype',
+                },
+              },
+            },
+          },
+          checklistOpenDate: {
+            [config]: {
+              dataType: DATA_TYPE_DATE,
+              messages: defineMessages({
+                fullName: {
+                  id: 'field.groups_checklist.checklistOpenDate.fullName',
+                  defaultMessage: 'Checklist start date',
+                },
+                name: {
+                  id: 'field.groups_checklist.checklistOpenDate.name',
+                  defaultMessage: 'Start',
+                },
+              }),
+              view: {
+                type: DateInput,
+              },
+            },
+          },
+          checklistCloseDate: {
+            [config]: {
+              dataType: DATA_TYPE_DATE,
+              messages: defineMessages({
+                fullName: {
+                  id: 'field.groups_checklist.checklistCloseDate.fullName',
+                  defaultMessage: 'Checklist close date',
+                },
+                name: {
+                  id: 'field.groups_checklist.checklistCloseDate.name',
+                  defaultMessage: 'Close',
+                },
+              }),
+              view: {
+                type: DateInput,
+              },
+            },
+          },
+          checklistNote: {
+            [config]: {
+              messages: defineMessages({
+                fullName: {
+                  id: 'field.groups_checklist.checklistNote.fullName',
+                  defaultMessage: 'Checklist note',
+                },
+                name: {
+                  id: 'field.groups_checklist.checklistNote.name',
+                  defaultMessage: 'Note',
+                },
+              }),
+              view: {
+                type: TextInput,
+                props: {
+                  multiline: true,
+                },
+              },
+            },
+          },
+          checklistItemGroupList: {
+            [config]: {
+              view: {
+                type: CompoundInput,
+              },
+            },
+            checklistItemGroup: {
+              [config]: {
+                messages: defineMessages({
+                  name: {
+                    id: 'field.groups_checklist.checklistItemGroup.name',
+                    defaultMessage: 'Checklist items',
+                  },
+                }),
+                repeating: true,
+                view: {
+                  type: CompoundInput,
+                  props: {
+                    tabular: true,
+                  },
+                },
+              },
+              checklistItem: {
+                [config]: {
+                  messages: defineMessages({
+                    fullName: {
+                      id: 'field.groups_checklist.checklistItem.fullName',
+                      defaultMessage: 'Checklist item',
+                    },
+                    name: {
+                      id: 'field.groups_checklist.checklistItem.name',
+                      defaultMessage: 'Item',
+                    },
+                  }),
+                  view: {
+                    type: TextInput,
+                  },
+                },
+              },
+              checklistAssignee: {
+                [config]: {
+                  messages: defineMessages({
+                    name: {
+                      id: 'field.groups_checklist.checklistAssignee.name',
+                      defaultMessage: 'Assigned to',
+                    },
+                  }),
+                  view: {
+                    type: AutocompleteInput,
+                    props: {
+                      source: 'person/local,person/shared,person/ulan',
+                    },
+                  },
+                },
+              },
+              checklistStatus: {
+                [config]: {
+                  messages: defineMessages({
+                    name: {
+                      id: 'field.groups_checklist.checklistStatus.name',
+                      defaultMessage: 'Status',
+                    },
+                  }),
+                  view: {
+                    type: TermPickerInput,
+                    props: {
+                      source: 'checkliststatus',
+                    },
+                  },
+                },
+              },
+              checklistStatusDate: {
+                [config]: {
+                  dataType: DATA_TYPE_DATE,
+                  messages: defineMessages({
+                    fullName: {
+                      id: 'field.groups_checklist.checklistStatusDate.fullName',
+                      defaultMessage: 'Status date',
+                    },
+                    name: {
+                      id: 'field.groups_checklist.checklistStatusDate.name',
+                      defaultMessage: 'Date',
+                    },
+                  }),
+                  view: {
+                    type: DateInput,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/extensions/checklist/form.jsx
+++ b/src/plugins/extensions/checklist/form.jsx
@@ -1,0 +1,41 @@
+export default (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  return (
+    <Panel name="checklist" collapsible collapsed>
+      <Field name="checklistGroupList" subpath="ns2:groups_checklist">
+        <Field name="checklistGroup">
+          <Panel>
+            <Row>
+              <Field name="checklistType" />
+              <Field name="checklistOpenDate" />
+              <Field name="checklistCloseDate" />
+            </Row>
+
+            <Field name="checklistNote" />
+
+            <Field name="checklistItemGroupList">
+              <Field name="checklistItemGroup">
+                <Field name="checklistItem" />
+                <Field name="checklistAssignee" />
+                <Field name="checklistStatus" />
+                <Field name="checklistStatusDate" />
+              </Field>
+            </Field>
+          </Panel>
+        </Field>
+      </Field>
+    </Panel>
+  );
+};

--- a/src/plugins/extensions/checklist/index.js
+++ b/src/plugins/extensions/checklist/index.js
@@ -1,0 +1,17 @@
+import fields from './fields';
+import form from './form';
+import messages from './messages';
+
+export default () => (configContext) => ({
+  extensions: {
+    checklist: {
+      fields: fields(configContext),
+      form: form(configContext),
+    },
+  },
+  recordTypes: {
+    group: {
+      messages,
+    },
+  },
+});

--- a/src/plugins/extensions/checklist/messages.js
+++ b/src/plugins/extensions/checklist/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  panel: defineMessages({
+    checklist: {
+      id: 'panel.ext.checklist.checklist',
+      defaultMessage: 'Checklist Information',
+    },
+  }),
+};

--- a/src/plugins/extensions/index.js
+++ b/src/plugins/extensions/index.js
@@ -1,10 +1,12 @@
 import address from './address';
+import checklist from './checklist';
 import commission from './commission';
 import dimension from './dimension';
 import socialMedia from './socialMedia';
 
 export default [
   address,
+  checklist,
   commission,
   dimension,
   socialMedia,

--- a/src/plugins/recordTypes/group/fields.js
+++ b/src/plugins/recordTypes/group/fields.js
@@ -7,6 +7,10 @@ export default (configContext) => {
     configKey: config,
   } = configContext.configHelpers;
 
+  const {
+    extensions,
+  } = configContext.config;
+
   return {
     document: {
       'ns2:groups_common': {
@@ -30,6 +34,7 @@ export default (configContext) => {
           },
         },
       },
+      ...extensions.checklist.fields,
     },
   };
 };

--- a/src/plugins/recordTypes/group/forms/default.jsx
+++ b/src/plugins/recordTypes/group/forms/default.jsx
@@ -1,0 +1,50 @@
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Cols,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Field name="title" />
+
+        <Cols>
+          <Col>
+            <Field name="responsibleDepartment" />
+            <Field name="owner" />
+          </Col>
+
+          <Col>
+            <Row>
+              <Field name="groupEarliestSingleDate" />
+              <Field name="groupLatestDate" />
+            </Row>
+          </Col>
+        </Cols>
+
+        <Field name="scopeNote" />
+      </Panel>
+
+      {extensions.checklist.form}
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/group/forms/index.js
+++ b/src/plugins/recordTypes/group/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/group/index.js
+++ b/src/plugins/recordTypes/group/index.js
@@ -1,9 +1,11 @@
 import fields from './fields';
+import forms from './forms';
 
 export default () => (configContext) => ({
   recordTypes: {
     group: {
       fields: fields(configContext),
+      forms: forms(configContext),
     },
   },
 });


### PR DESCRIPTION
Resolves: https://collectionspace.atlassian.net/browse/DRYD-940

## Notes

I wasn't entirely sure how best to show the multiple checklists like in the wireframe. This shows them all under the `Checklist Information` panel rather than having the panel be replicated each time a new checklist is made. I tried moving the panel into the `checklistGroupList` but it felt a little odd in the UI, though it did make each checklist collapsible which was nice. 