### PR TITLE
DRYD-1015: Add Artwork Tag field to Object records.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-publicart",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-publicart",
-      "version": "4.0.5",
+      "version": "4.1.0",
       "license": "ECL-2.0",
       "dependencies": {
         "react-intl": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-publicart",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Public Art profile plugin for the CollectionSpace UI",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",

--- a/src/messages.js
+++ b/src/messages.js
@@ -5,6 +5,8 @@ export default {
 
   'field.collectionobjects_common.objectNumber.name': 'Artwork ID',
   'field.collectionobjects_common.briefDescription.name': 'Artwork description',
+  'field.collectionobjects_common.contentConcept.fullName': 'Artwork tag',
+  'field.collectionobjects_common.contentConcept.name': 'Artwork tag',
   'field.collectionobjects_common.objectNameGroup.name': 'Work type',
   'field.collectionobjects_common.objectName.fullName': 'Work type',
   'field.collectionobjects_common.objectName.name': 'Type',

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -92,6 +92,17 @@ export default (configContext) => {
             },
           },
         },
+        contentConcepts: {
+          contentConcept: {
+            [config]: {
+              view: {
+                props: {
+                  source: 'concept/associated',
+                },
+              },
+            },
+          },
+        },
         objectProductionDateGroupList: {
           // Replaced by publicartProductionDateGroupList. Hide from search.
           [config]: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -50,6 +50,10 @@ const template = (configContext) => {
               <Field name="briefDescription" />
             </Field>
 
+            <Field name="contentConcepts">
+              <Field name="contentConcept" />
+            </Field>
+
             <Field name="distinguishingFeatures" />
 
             <Field name="comments">

--- a/src/plugins/recordTypes/collectionobject/forms/tombstone.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/tombstone.jsx
@@ -36,6 +36,10 @@ const template = (configContext) => {
               <Field name="briefDescription" />
             </Field>
 
+            <Field name="contentConcepts">
+              <Field name="contentConcept" />
+            </Field>
+
             <Field name="computedCurrentLocation" />
           </Col>
         </Row>

--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -4,9 +4,6 @@ export default {
   activity: {
     disabled: true,
   },
-  associated: {
-    disabled: true,
-  },
   worktype: {
     messages: defineMessages({
       name: {


### PR DESCRIPTION
**What does this do?**

This adds the Artwork Tag field to Object records. This is the `collectionobjects_common:contentConcepts/contentConcept` field from core, which was previously hidden in public art. It is now unhidden, placed below the Artwork Description field, and relabeled as "Artwork tag". The autocomplete has been restricted to only draw from the Associated Concept authority.

**Why are we doing this? (with JIRA link)**

This allows users to tag Objects.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1015

**How should this be tested? Do these changes have associated tests?**

- Edit an Object.
- Select the Standard Template. Below the "Artwork description" field, there should be an "Artwork tag" field. 
- Enter a value. It should be possible to add the value to the Associated Concept authority (and no others).
- Save the record, with a value entered into Artwork tag. The value should be retained.

Repeat the above, selecting the Tombstone template.

**Dependencies for merging? Releasing to production?**

https://github.com/collectionspace/application/pull/259 should be merged first, to unhide the Associated Concept authority.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested this locally.