### PR TITLE
DRYD-987: Add shared authorities to commissioning body.

### DIFF
--- a/src/plugins/extensions/commission/fields.js
+++ b/src/plugins/extensions/commission/fields.js
@@ -48,7 +48,7 @@ export default (configContext) => {
             view: {
               type: AutocompleteInput,
               props: {
-                source: 'person/local,organization/local',
+                source: 'person/local,person/shared,organization/local,organization/shared',
               },
             },
           },


### PR DESCRIPTION
**What does this do?**

This adds the Shared Person and Shared Organization authorities to the autocomplete sources for the Commissioning Body field on Acquisition records.

**Why are we doing this? (with JIRA link)**

JIRA: https://collectionspace.atlassian.net/browse/DRYD-987

**How should this be tested? Do these changes have associated tests?**

- Create or edit an Acquision.
- In the Commissioning Body field (Commission Information section), enter some text.
Shared Persons and Shared Organizations should appear as authorities to which a new term can be added (in addition to Local Persons and Local Organizations).

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested locally.