### PR TITLE
DRYD-1234: Add approvalGroup to acquisition

### DIFF
--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -52,6 +52,15 @@ const template = (configContext) => {
           </Col>
         </Cols>
 
+        <Field name="approvalGroupList">
+          <Field name="approvalGroup">
+            <Field name="approvalGroup" />
+            <Field name="approvalIndividual" />
+            <Field name="approvalStatus" />
+            <Field name="approvalDate" />
+            <Field name="approvalNote" />
+          </Field>
+        </Field>
         <Field name="acquisitionNote" />
 
         <Row>


### PR DESCRIPTION
**What does this do?**
Adds approval group to acquisition form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1234

**How should this be tested? Do these changes have associated tests?**
* Build and run cspace with publicart enabled
* Run the devserver
* Create an acquisition with an approval group filled out

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested created and loading an acquisition with an approval group on publicart