### PR TITLE
DRYD-1255: Remove annotation fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -63,15 +63,6 @@ const template = (configContext) => {
           </Col>
         </Row>
 
-        <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
-          <Field name="annotationGroup">
-            <Field name="annotationType" />
-            <Field name="annotationNote" />
-            <Field name="annotationDate" />
-            <Field name="annotationAuthor" />
-          </Field>
-        </Field>
-
         <Field name="titleGroupList">
           <Field name="titleGroup">
             <Panel>


### PR DESCRIPTION
**What does this do?**
Removes annotation group fields from the default collectionspace form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1255

An additional change was requested to pull remove the annotation fields.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* When creating a collectionobject the annotation group should no longer exist

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install