### PR TITLE
DRYD-1217: Disable archaeological place authority

### DIFF
--- a/src/plugins/recordTypes/place/vocabularies.js
+++ b/src/plugins/recordTypes/place/vocabularies.js
@@ -4,6 +4,9 @@ export default {
   tgn: {
     disabled: true,
   },
+  archaeological: {
+    disabled: true,
+  },
   shared: {
     messages: defineMessages({
       name: {


### PR DESCRIPTION
**What does this do?**
Disables the archaeological site place authority 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1217

The archaeological site is only needed for core and anthro, so it's being disabled in other profiles.

**How should this be tested? Do these changes have associated tests?**
* Build cspace with the publicart profile enabled
* Run the devserver
* Verify that the archaeological site is not visible when trying to create a place authority

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance