### PR TITLE
DRYD-1326: Update exit reasons list

### DIFF
--- a/src/plugins/recordTypes/objectexit/index.js
+++ b/src/plugins/recordTypes/objectexit/index.js
@@ -1,6 +1,8 @@
 import forms from './forms';
+import optionLists from './optionLists';
 
 export default () => (configContext) => ({
+  optionLists,
   recordTypes: {
     objectexit: {
       forms: forms(configContext),

--- a/src/plugins/recordTypes/objectexit/optionLists.js
+++ b/src/plugins/recordTypes/objectexit/optionLists.js
@@ -3,9 +3,6 @@ import { defineMessages } from 'react-intl';
 export default {
   exitReasons: {
     values: [
-      'deaccession',
-      'disposal',
-      'returnofloan',
       'temporary',
       'transfer',
       'painted out',
@@ -13,18 +10,6 @@ export default {
       'lost to demolition',
     ],
     messages: defineMessages({
-      deaccession: {
-        id: 'option.exitReasons.deaccession',
-        defaultMessage: 'deaccession',
-      },
-      disposal: {
-        id: 'option.exitReasons.disposal',
-        defaultMessage: 'disposal',
-      },
-      returnofloan: {
-        id: 'option.exitReasons.returnofloan',
-        defaultMessage: 'return of loan',
-      },
       temporary: {
         id: 'option.exitReasons.temporary',
         defaultMessage: 'temporary',

--- a/src/plugins/recordTypes/objectexit/optionLists.js
+++ b/src/plugins/recordTypes/objectexit/optionLists.js
@@ -1,0 +1,50 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  exitReasons: {
+    values: [
+      'deaccession',
+      'disposal',
+      'returnofloan',
+      'temporary',
+      'transfer',
+      'painted out',
+      'covered by construction',
+      'lost to demolition',
+    ],
+    messages: defineMessages({
+      deaccession: {
+        id: 'option.exitReasons.deaccession',
+        defaultMessage: 'deaccession',
+      },
+      disposal: {
+        id: 'option.exitReasons.disposal',
+        defaultMessage: 'disposal',
+      },
+      returnofloan: {
+        id: 'option.exitReasons.returnofloan',
+        defaultMessage: 'return of loan',
+      },
+      temporary: {
+        id: 'option.exitReasons.temporary',
+        defaultMessage: 'temporary',
+      },
+      transfer: {
+        id: 'option.exitReasons.transfer',
+        defaultMessage: 'transfer',
+      },
+      'painted out': {
+        id: 'option.exitReasons.painted out',
+        defaultMessage: 'painted out',
+      },
+      'covered by construction': {
+        id: 'option.exitReasons.covered by construction',
+        defaultMessage: 'covered by construction',
+      },
+      'lost to demolition': {
+        id: 'option.exitReasons.lost to demolition',
+        defaultMessage: 'lost to demolition',
+      },
+    }),
+  },
+};

--- a/src/plugins/recordTypes/objectexit/optionLists.js
+++ b/src/plugins/recordTypes/objectexit/optionLists.js
@@ -3,6 +3,9 @@ import { defineMessages } from 'react-intl';
 export default {
   exitReasons: {
     values: [
+      'deaccession',
+      'disposal',
+      'returnofloan',
       'temporary',
       'transfer',
       'painted out',


### PR DESCRIPTION
**What does this do?**
Adds values to exit reasons list

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1326

This is just updating the exit reasons list to include additional values for PublicArt

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create an object exit
* See the new values for 'Exit reason'

**Dependencies for merging? Releasing to production?**
The old value for `returnofloan` did not have any spaces in it, so I left it as is.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance