### PR TITLE
DRYD-1374: Add objectCountGroup fields for collectionobject

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -23,7 +23,6 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="numberOfObjects" />
 
             <Field name="responsibleDepartments">
               <Field name="responsibleDepartment" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -94,6 +94,16 @@ const template = (configContext) => {
           </Field>
         </Field>
 
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
+          </Field>
+        </Field>
+
         <Row>
           <Field name="owners">
             <Field name="owner" />


### PR DESCRIPTION
**What does this do?**
* Add objectCountGroupList to the collectionobject form
* Removes numberOfObjects

**Why are we doing this? (with JIRA link)**
This is a combination of 2 jiras:
* https://collectionspace.atlassian.net/browse/DRYD-1374
* https://collectionspace.atlassian.net/browse/DRYD-1379

This replaces the use of numberOfObjects with the new object count fields.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Add a object count
* Observer that numberOfObjects no longer displays

**Dependencies for merging? Releasing to production?**
This requires the application PR for the `objectcounttypes` vocabulary in order to populate the `objectCountType` field.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally