### PR TITLE
DRYD-1206: Add nameNote to organization form

### DIFF
--- a/src/plugins/recordTypes/organization/forms/default.jsx
+++ b/src/plugins/recordTypes/organization/forms/default.jsx
@@ -73,6 +73,8 @@ const template = (configContext) => {
           </Col>
 
           <Col>
+            <Field name="nameNote" />
+
             <Field name="historyNotes">
               <Field name="historyNote" />
             </Field>


### PR DESCRIPTION
**What does this do?**
Adds nameNote to the default organization form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1206

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create an organization authority with a nameNote

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance