### PR TITLE
DRYD-1493: Add annotation block

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -62,6 +62,19 @@ const template = (configContext) => {
           </Col>
         </Row>
 
+        <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
+          <Field name="annotationGroup">
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
+          </Field>
+        </Field>
+
         <Field name="titleGroupList">
           <Field name="titleGroup">
             <Panel>

--- a/src/plugins/recordTypes/collectionobject/forms/tombstone.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/tombstone.jsx
@@ -44,6 +44,19 @@ const template = (configContext) => {
           </Col>
         </Row>
 
+        <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
+          <Field name="annotationGroup">
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
+          </Field>
+        </Field>
+
         <Field name="titleGroupList">
           <Field name="titleGroup">
             <Field name="title" embedded label="" />


### PR DESCRIPTION
**What does this do?**
* Adds annotation fields to collectionobject templates

**Why are we doing this? (with JIRA link)**
Jira: https://github.com/collectionspace/cspace-ui-plugin-profile-lhmc.js/pull/19

These fields were requested to be added to the publicart profile.

**How should this be tested? Do these changes have associated tests?**
* Run the devsever: `npm run devserver --back-end=https://publicart.dev.collectionspace.org`
* Create a collectionobject with annotatio fields

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with publicart.dev as a backend