### PR TITLE
Adjust Annotation Block

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -62,19 +62,6 @@ const template = (configContext) => {
           </Col>
         </Row>
 
-        <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
-          <Field name="annotationGroup">
-            <Panel>
-              <Row>
-                <Field name="annotationType" />
-                <Field name="annotationDate" />
-                <Field name="annotationAuthor" />
-              </Row>
-              <Field name="annotationNote" />
-            </Panel>
-          </Field>
-        </Field>
-
         <Field name="titleGroupList">
           <Field name="titleGroup">
             <Panel>
@@ -174,6 +161,19 @@ const template = (configContext) => {
         </Field>
 
         <Field name="objectProductionNote" />
+
+        <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
+          <Field name="annotationGroup">
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="hierarchy" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/tombstone.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/tombstone.jsx
@@ -44,19 +44,6 @@ const template = (configContext) => {
           </Col>
         </Row>
 
-        <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
-          <Field name="annotationGroup">
-            <Panel>
-              <Row>
-                <Field name="annotationType" />
-                <Field name="annotationDate" />
-                <Field name="annotationAuthor" />
-              </Row>
-              <Field name="annotationNote" />
-            </Panel>
-          </Field>
-        </Field>
-
         <Field name="titleGroupList">
           <Field name="titleGroup">
             <Field name="title" embedded label="" />


### PR DESCRIPTION
**What does this do?**
* Remove the annotation block from the tombstone profile
* Move the annotation block under the production note

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1493

These are adjustments from feedback on DRYD-1493.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver using dev as a backend
* Create a CollectionObject
* Check that the annotation block in underneath the object production note on the default profile
* Check that the annotation block is not visible on the tombstone profile

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with materials dev as a backend