### PR TITLE
Add shared person/org auth vocabs to deaccession/exit controlled fields

### DIFF
--- a/src/plugins/recordTypes/deaccession/fields.js
+++ b/src/plugins/recordTypes/deaccession/fields.js
@@ -1,0 +1,42 @@
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+  } = configContext.inputComponents;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  return {
+    document: {
+      'ns2:deaccessions_common': {
+        deaccessionApprovalGroupList: {
+          deaccessionApprovalGroup: {
+            deaccessionApprovalIndividual: {
+              [config]: {
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/shared',
+                  },
+                },
+              },
+            },
+          },
+        },
+        exitRecipients: {
+          exitRecipient: {
+            [config]: {
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'person/local,person/shared,organization/local,organization/shared',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/deaccession/fields.js
+++ b/src/plugins/recordTypes/deaccession/fields.js
@@ -1,9 +1,5 @@
 export default (configContext) => {
   const {
-    AutocompleteInput,
-  } = configContext.inputComponents;
-
-  const {
     configKey: config,
   } = configContext.configHelpers;
 
@@ -15,7 +11,6 @@ export default (configContext) => {
             deaccessionApprovalIndividual: {
               [config]: {
                 view: {
-                  type: AutocompleteInput,
                   props: {
                     source: 'person/local,person/shared',
                   },
@@ -28,7 +23,6 @@ export default (configContext) => {
           exitRecipient: {
             [config]: {
               view: {
-                type: AutocompleteInput,
                 props: {
                   source: 'person/local,person/shared,organization/local,organization/shared',
                 },

--- a/src/plugins/recordTypes/deaccession/index.js
+++ b/src/plugins/recordTypes/deaccession/index.js
@@ -1,0 +1,9 @@
+import fields from './fields';
+
+export default () => (configContext) => ({
+  recordTypes: {
+    deaccession: {
+      fields: fields(configContext),
+    },
+  },
+});

--- a/src/plugins/recordTypes/exit/fields.js
+++ b/src/plugins/recordTypes/exit/fields.js
@@ -1,9 +1,5 @@
 export default (configContext) => {
   const {
-    AutocompleteInput,
-  } = configContext.inputComponents;
-
-  const {
     configKey: config,
   } = configContext.configHelpers;
 
@@ -14,7 +10,6 @@ export default (configContext) => {
           owner: {
             [config]: {
               view: {
-                type: AutocompleteInput,
                 props: {
                   source: 'person/local,person/shared,organization/local,organization/shared',
                 },
@@ -27,7 +22,6 @@ export default (configContext) => {
             agent: {
               [config]: {
                 view: {
-                  type: AutocompleteInput,
                   props: {
                     source: 'person/local,person/shared,organization/local,organization/shared',
                   },
@@ -41,7 +35,6 @@ export default (configContext) => {
             individual: {
               [config]: {
                 view: {
-                  type: AutocompleteInput,
                   props: {
                     source: 'person/local,person/shared',
                   },

--- a/src/plugins/recordTypes/exit/fields.js
+++ b/src/plugins/recordTypes/exit/fields.js
@@ -1,0 +1,56 @@
+export default (configContext) => {
+  const {
+    AutocompleteInput,
+  } = configContext.inputComponents;
+
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  return {
+    document: {
+      'ns2:exits_common': {
+        owners: {
+          owner: {
+            [config]: {
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'person/local,person/shared,organization/local,organization/shared',
+                },
+              },
+            },
+          },
+        },
+        exitAgentGroupList: {
+          exitAgentGroup: {
+            agent: {
+              [config]: {
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/shared,organization/local,organization/shared',
+                  },
+                },
+              },
+            },
+          },
+        },
+        approvalStatusGroupList: {
+          approvalStatusGroup: {
+            individual: {
+              [config]: {
+                view: {
+                  type: AutocompleteInput,
+                  props: {
+                    source: 'person/local,person/shared',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/exit/index.js
+++ b/src/plugins/recordTypes/exit/index.js
@@ -1,0 +1,9 @@
+import fields from './fields';
+
+export default () => (configContext) => ({
+  recordTypes: {
+    exit: {
+      fields: fields(configContext),
+    },
+  },
+});

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -4,7 +4,9 @@ import collectionobject from './collectionobject';
 import concept from './concept';
 import conditioncheck from './conditioncheck';
 import conservation from './conservation';
+import deaccession from './deaccession';
 import exhibition from './exhibition';
+import exit from './exit';
 import group from './group';
 import intake from './intake';
 import iterationreport from './iterationreport';
@@ -26,7 +28,9 @@ export default [
   concept,
   conditioncheck,
   conservation,
+  deaccession,
   exhibition,
+  exit,
   group,
   intake,
   iterationreport,


### PR DESCRIPTION
**What does this do?**

Adds person/shared to deaccession and exit fields controlled by person/local. Adds organization/shared to deaccession and exit fields controlled by organization/local.

**Why are we doing this? (with JIRA link)**

Client request, in [DRYD-1753](https://collectionspace.atlassian.net/browse/DRYD-1753)

**How should this be tested? Do these changes have associated tests?**

I did not add any tests. 

**Dependencies for merging? Releasing to production?**

None known.

**Has the application documentation been updated for these changes?**

n/a ?

**Did someone actually run this code to verify it works?**

Not yet. We don't host any publicart profile clients so my known process for a dev environment doesn't work for this one. 