### PR TITLE
Release 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## v7.0.2
-v7.0.2 adds support for CollectionSpace 8.3.0, and requires cspace-ui version 10.2.0.
+## v7.1.0
+v7.1.0 adds support for CollectionSpace 8.3.0, and requires cspace-ui version 10.2.0.
 
 - Added the Acquisition description free text field (`acquisitionDescription`) to the record editor for Acquisitions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-publicart",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-publicart",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "ECL-2.0",
       "dependencies": {
         "react-intl": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-publicart",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Public Art profile plugin for the CollectionSpace UI",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
What does this do?
This updates the package version to 7.1.0 to signify the next release.

When the PR is merged we can publish the relevant draft release https://github.com/collectionspace/cspace-ui-plugin-profile-publicart.js/releases/edit/untagged-f5ba2e200b1f94e294cc